### PR TITLE
Compatibility with ue5.0.0

### DIFF
--- a/plugins/basic/bootstrap.py
+++ b/plugins/basic/bootstrap.py
@@ -9,5 +9,11 @@ import os
 plugin_root_dir = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(plugin_root_dir, "python"))
 
+# Add sgtk path to sys.path
+import pathlib
+sgtk_core_path = pathlib.Path(plugin_root_dir.split("app_store")[0])
+sgtk_core_path = sgtk_core_path / "core" / "python"
+sys.path.insert(0, str(sgtk_core_path))
+
 from tk_unreal_basic import plugin_bootstrap
 plugin_bootstrap.bootstrap_plugin(plugin_root_dir)

--- a/plugins/basic/python/tk_unreal_basic/plugin_bootstrap.py
+++ b/plugins/basic/python/tk_unreal_basic/plugin_bootstrap.py
@@ -47,7 +47,7 @@ def bootstrap_plugin(plugin_root_path):
 
     # synchronous
     manager.bootstrap_engine(
-        os.environ.get("SHOTGUN_ENGINE", "tk-unreal"),
+        os.environ.get("SHOTGRID_ENGINE", "tk-unreal"),
         manager.get_entity_from_environment()
     )
     _on_engine_initialized()
@@ -67,7 +67,7 @@ def _on_engine_initialized():
     
     import unreal
     
-    unreal.ShotgunEngine.get_instance().on_engine_initialized()
+    unreal.ShotgridEngine.get_instance().on_engine_initialized()
 
     
 def _initialize_manager(plugin_root_path):

--- a/plugins/basic/python/tk_unreal_basic/plugin_bootstrap.py
+++ b/plugins/basic/python/tk_unreal_basic/plugin_bootstrap.py
@@ -47,7 +47,7 @@ def bootstrap_plugin(plugin_root_path):
 
     # synchronous
     manager.bootstrap_engine(
-        os.environ.get("SHOTGRID_ENGINE", "tk-unreal"),
+        os.environ.get("SHOTGUN_ENGINE", "tk-unreal"),
         manager.get_entity_from_environment()
     )
     _on_engine_initialized()

--- a/python/tk_unreal/unreal_sg_engine.py
+++ b/python/tk_unreal/unreal_sg_engine.py
@@ -8,10 +8,10 @@ from . import config
 import sys
 import os
 
-unreal.log("Loading Shotgun Engine for Unreal from {}".format(__file__))
+unreal.log("Loading Shotgrid Engine for Unreal from {}".format(__file__))
 
 @unreal.uclass()
-class ShotgunEngineWrapper(unreal.ShotgunEngine):
+class ShotgridEngineWrapper(unreal.ShotgridEngine):
 
     def _post_init(self):
         """
@@ -20,23 +20,23 @@ class ShotgunEngineWrapper(unreal.ShotgunEngine):
         config.wrapper_instance = self
         
     @unreal.ufunction(override=True)
-    def get_shotgun_menu_items(self):
+    def get_shotgrid_menu_items(self):
         """
-        Returns the list of available menu items to populate the Shotgun menu in Unreal
+        Returns the list of available menu items to populate the Shotgrid menu in Unreal
         """
         menu_items = []
         
         engine = sgtk.platform.current_engine()
         menu_items = self.create_menu(engine)
 
-        unreal.log("get_shotgun_menu_items returned: {0}".format(menu_items.__str__()))
+        unreal.log("get_shotgrid_menu_items returned: {0}".format(menu_items.__str__()))
 
         return menu_items
 
     @unreal.ufunction(override=True)
     def execute_command(self, command_name):
         """
-        Callback to execute the menu item selected in the Shotgun menu in Unreal
+        Callback to execute the menu item selected in the Shotgrid menu in Unreal
         """
         engine = sgtk.platform.current_engine()
 
@@ -255,7 +255,7 @@ class ShotgunEngineWrapper(unreal.ShotgunEngine):
         """
         Adds a new Unreal ShotgunMenuItem to the menu items
         """
-        menu_item = unreal.ShotgunMenuItem()
+        menu_item = unreal.ShotgridMenuItem()
         menu_item.title = title
         menu_item.name = name
         menu_item.type = type


### PR DESCRIPTION
Tested with Unreal 5.0.0 official release.

## Problem
Many errors when trying to launch unreal with tk-unreal bootstrap for Unreal 5.0.0
Maybe some Shotgun plugins classes and methods has been renamed to Shotgrid, and we need to update tk-unreal configuration ?

## Changes
plugins/basic/python/tk_unreal_basic/plugin_bootstrap.py : 
- rename ShotgunEngine call to ShotgridEngine

python/tk_unreal/unreal_sg_engine.py:
- rename class and inheritance ShotgunEngineWrapper to ShotgridEngineWrapper
- rename overrided function get_shotgun_menu_items to get_shotgrid_menu_items
- rename unreal.ShotgunMenuItem() to unreal.ShotgridMenuItem()

plugins/basic/bootstrap.py:
- Workaround to use sgtk python module in Unreal Engine editor, need help/review on this part, because i'm not able to import sgtk in unreal without this.

Thank you